### PR TITLE
Correcciones Menores #1

### DIFF
--- a/Ejercicio de estructuras repetitivas promedio de estudiantes.cpp
+++ b/Ejercicio de estructuras repetitivas promedio de estudiantes.cpp
@@ -1,23 +1,14 @@
-#include<iostream>
-#include<string>
-
+#include <iostream>
 using namespace std;
 
 int main()
 {	
-	string opciones;
-	int n, suma, cont, desaprobados, aprobados;
-	string nombre, nombreEstudiante, RegistroNombre;
+	int n,suma=0,cont=0,desaprobados=0,aprobados=0;
+	string opciones,nombre,nombreEstudiante,RegistroNombre="";
 	float promedio;
-	RegistroNombre= ""; //Se quita el espacio incial de la variable RegistroNombre
-	suma=0;
-	cont=0;
-	desaprobados=0;
-	aprobados=0;
 	cout<<"\nBIENVENIDO AL REGISTRO DE NOTAS"<<endl;
 	cout<<"\nRegistre su nombre: ";
 	cin>>nombre;
-	
 	do
 	{
 		cout<<"\nRegistre nombre del estudiante: ";
@@ -29,28 +20,25 @@ int main()
 		if(n>10.5)
 		{
 			aprobados++;
-			RegistroNombre+=to_string(cont)+". "+nombreEstudiante+" Aprobo"+"\n"; //los estudiantes son enumerados y mostrados como aprobados
+			RegistroNombre+="- El estudiante "+nombreEstudiante+" ha aprobado\n"; //los estudiantes son enumerados y mostrados como aprobados
 		}else 
 		{
 			desaprobados++;
-			RegistroNombre+=to_string(cont)+". "+nombreEstudiante+" Desaprobo"+"\n"; //Los estudiantes son enumerados y mostrados como desaprovados
+			RegistroNombre+="- El estudiante "+nombreEstudiante+" ha desaprobado\n"; //Los estudiantes son enumerados y mostrados como desaprobados
 		}
 
-		cout<<"Desea continuar (si/no): ";
+		cout<<"Desea continuar? (si/no): ";
 		cin>>opciones;
 	}
-	while(opciones=="si");
-
+	while(opciones=="si");		
+	promedio=suma/cont;
 	cout<<"\nDatos obtenidos"<<endl;
 	cout<<"\nNombre del registrador de notas: "<<nombre<<endl; //Se denomina al usuario como registrador de notas
-	promedio=suma/cont;
 	cout<<"El promedio de las notas es: "<<promedio<<endl;
-	cout<<"Cantidad de estudiantes registrados:"<<cont<<endl;
+	cout<<"Cantidad de estudiantes registrados: "<<cont<<endl;
 	cout<<"Cantidad de estudiantes aprobados: "<<aprobados<<endl;
-	cout<<"Cantidad de estudiantes desaprobados: "<<desaprobados<<endl;
-	cout<<"Lista de estudiantes registrados: "<<endl<<RegistroNombre; //Se cambia el enunciado de "Lista de estudiantes que fueron registrados" a "Lista de estudiantes registrados" y termina con un cambio de linea
-	
-	
+	cout<<"Cantidad de estudiantes desaprobados: "<<desaprobados<<endl;	
+	cout<<"Lista de estudiantes registrados:\n"<<RegistroNombre<<endl;
 	return 0;
 		
 }


### PR DESCRIPTION
Eliminación del llamado a la librería <string> por errores en la conversión de la variable entera "cont" a cadena de texto, donde no reconocía la función "to_string". Error presentado en Dev-C++ versión 5.11

![Captura de pantalla (12)](https://github.com/JoseEsis/estructuras-repetitivas/assets/172610773/2e2336f3-3227-4a8a-ae3c-032c4c72d513)
